### PR TITLE
Implementa módulos de pedidos para comercio

### DIFF
--- a/src/main/java/com/rescuebites/api/cart/controllers/requests/UpdatePaymentMethodRequest.java
+++ b/src/main/java/com/rescuebites/api/cart/controllers/requests/UpdatePaymentMethodRequest.java
@@ -1,0 +1,12 @@
+package com.rescuebites.api.cart.controllers.requests;
+
+import com.rescuebites.api.order.data.enums.PaymentMethod;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdatePaymentMethodRequest(
+
+        @NotNull(message = "El método de pago es obligatorio")
+        @Schema(description = "Método de pago: MERCADO_PAGO o CASH", example = "MERCADO_PAGO")
+        PaymentMethod paymentMethod
+) {}

--- a/src/main/java/com/rescuebites/api/cart/controllers/responses/CommerceCartSummary.java
+++ b/src/main/java/com/rescuebites/api/cart/controllers/responses/CommerceCartSummary.java
@@ -1,0 +1,14 @@
+package com.rescuebites.api.cart.controllers.responses;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+public record CommerceCartSummary(
+        UUID commerceId,
+        String commerceName,
+        String address,
+        List<CartItemResponse> items,
+        BigDecimal subtotal,
+        Integer itemCount
+) {}

--- a/src/main/java/com/rescuebites/api/commerce/controllers/implementations/CommerceControllerImpl.java
+++ b/src/main/java/com/rescuebites/api/commerce/controllers/implementations/CommerceControllerImpl.java
@@ -2,6 +2,7 @@ package com.rescuebites.api.commerce.controllers.implementations;
 
 import com.rescuebites.api.commerce.controllers.interfaces.ICommerceController;
 import com.rescuebites.api.commerce.controllers.requests.CreateCommerceRequest;
+import com.rescuebites.api.commerce.controllers.requests.UpdateCommerceCredentialsRequest;
 import com.rescuebites.api.commerce.controllers.requests.UpdateCommerceRequest;
 import com.rescuebites.api.commerce.controllers.responses.CommerceResponse;
 import com.rescuebites.api.commerce.services.interfaces.ICommerceService;
@@ -35,5 +36,10 @@ public class CommerceControllerImpl implements ICommerceController {
     @Override
     public void deleteCommerce(UUID commerceId) {
         commerceService.deleteCommerce(commerceId);
+    }
+
+    @Override
+    public void updateCredentials(UUID commerceId, UpdateCommerceCredentialsRequest request) {
+        commerceService.updateCommerceCredentials(commerceId, request);
     }
 }

--- a/src/main/java/com/rescuebites/api/commerce/controllers/interfaces/ICommerceController.java
+++ b/src/main/java/com/rescuebites/api/commerce/controllers/interfaces/ICommerceController.java
@@ -1,8 +1,14 @@
 package com.rescuebites.api.commerce.controllers.interfaces;
 
 import com.rescuebites.api.commerce.controllers.requests.CreateCommerceRequest;
+import com.rescuebites.api.commerce.controllers.requests.UpdateCommerceCredentialsRequest;
 import com.rescuebites.api.commerce.controllers.requests.UpdateCommerceRequest;
 import com.rescuebites.api.commerce.controllers.responses.CommerceResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -33,4 +39,24 @@ public interface ICommerceController {
     @DeleteMapping("/{commerceId}")
     @ResponseStatus(NO_CONTENT)
     void deleteCommerce(@PathVariable UUID commerceId);
+
+    @PatchMapping("/{commerceId}/credentials")
+    @ResponseStatus(OK)
+    @Operation(
+            summary = "Actualizar credenciales de Mercado Pago",
+            description = "Permite al dueño del comercio actualizar su access token y webhook secret de Mercado Pago"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Credenciales actualizadas exitosamente"),
+            @ApiResponse(responseCode = "400", description = "Credenciales inválidas"),
+            @ApiResponse(responseCode = "403", description = "No tienes permiso para actualizar este comercio"),
+            @ApiResponse(responseCode = "404", description = "Comercio no encontrado")
+    })
+    void updateCredentials(
+            @Parameter(description = "ID del comercio", required = true)
+            @PathVariable UUID commerceId,
+
+            @Parameter(description = "Nuevas credenciales de Mercado Pago", required = true)
+            @RequestBody @Valid UpdateCommerceCredentialsRequest request
+    );
 }

--- a/src/main/java/com/rescuebites/api/commerce/controllers/requests/UpdateCommerceCredentialsRequest.java
+++ b/src/main/java/com/rescuebites/api/commerce/controllers/requests/UpdateCommerceCredentialsRequest.java
@@ -1,0 +1,17 @@
+package com.rescuebites.api.commerce.controllers.requests;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateCommerceCredentialsRequest {
+
+    @NotBlank(message = "El access token es obligatorio")
+    private String mercadoPagoAccessToken;
+
+    private String mercadoPagoWebhookSecret;
+}

--- a/src/main/java/com/rescuebites/api/commerce/data/models/Commerce.java
+++ b/src/main/java/com/rescuebites/api/commerce/data/models/Commerce.java
@@ -40,7 +40,7 @@ public class Commerce {
     @Size(max = 255, message = "La descripción debe tener entre 1 y 255 caracteres")
     private String description;
 
-    @ManyToMany
+    @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(
             name = "commerce_commerce_types",
             joinColumns = @JoinColumn(name = "commerce_id"),
@@ -67,6 +67,12 @@ public class Commerce {
             message = "El número de celular debe tener el formato válido argentino"
     )
     private String phone;
+
+    @Column(name = "mercado_pago_access_token")
+    private String mercadoPagoAccessToken;
+
+    @Column(name = "mercado_pago_webhook_secret")
+    private String mercadoPagoWebhookSecret;
 
     @OneToMany(mappedBy = "commerce", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default

--- a/src/main/java/com/rescuebites/api/commerce/facades/implementations/CommerceFacade.java
+++ b/src/main/java/com/rescuebites/api/commerce/facades/implementations/CommerceFacade.java
@@ -2,12 +2,15 @@ package com.rescuebites.api.commerce.facades.implementations;
 
 import com.rescuebites.api.commerce.controllers.requests.UpdateCommerceRequest;
 import com.rescuebites.api.commerce.data.enums.CommerceTypeEnum;
+import com.rescuebites.api.commerce.data.models.Commerce;
 import com.rescuebites.api.commerce.data.models.CommerceType;
 import com.rescuebites.api.commerce.facades.interfaces.ICommerceFacade;
 import com.rescuebites.api.commerce.repositories.ICommerceRepository;
 import com.rescuebites.api.commerce.repositories.ICommerceTypeRepository;
 import com.rescuebites.api.exceptions.custom_exceptions.DuplicateResourceException;
+import com.rescuebites.api.exceptions.custom_exceptions.ResourceNotFoundException;
 import com.rescuebites.api.exceptions.custom_exceptions.ValidationException;
+import com.rescuebites.api.security.utils.SecurityUtils;
 import com.rescuebites.api.users.data.models.User;
 import com.rescuebites.api.users.facades.interfaces.IUserFacade;
 import com.rescuebites.api.users.services.interfaces.ITokenService;
@@ -17,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -28,6 +32,18 @@ public class CommerceFacade implements ICommerceFacade {
     private final IUserFacade userFacade;
     private final ITokenService tokenService;
     private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public Commerce findCommerceByIdOrThrowException(UUID commerceId) {
+        return commerceRepository.findByCommerceIdAndDeletedFalse(commerceId)
+                .orElseThrow(() -> new ResourceNotFoundException("Commerce", "id", commerceId));
+    }
+
+    @Override
+    public void validateCommerceOwnership(UUID commerceId) {
+        Commerce commerce = findCommerceByIdOrThrowException(commerceId);
+        SecurityUtils.validateOwnership(commerce.getUser().getEmail());
+    }
 
     @Override
     public void ifCommerceNameAlreadyExistsThrowException(String name) {

--- a/src/main/java/com/rescuebites/api/commerce/facades/interfaces/ICommerceFacade.java
+++ b/src/main/java/com/rescuebites/api/commerce/facades/interfaces/ICommerceFacade.java
@@ -1,14 +1,19 @@
 package com.rescuebites.api.commerce.facades.interfaces;
 
-import com.rescuebites.api.client.controllers.requests.UpdateClientRequest;
 import com.rescuebites.api.commerce.controllers.requests.UpdateCommerceRequest;
 import com.rescuebites.api.commerce.data.enums.CommerceTypeEnum;
+import com.rescuebites.api.commerce.data.models.Commerce;
 import com.rescuebites.api.commerce.data.models.CommerceType;
 import com.rescuebites.api.users.data.models.User;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface ICommerceFacade {
+
+    Commerce findCommerceByIdOrThrowException(UUID commerceId);
+
+    void validateCommerceOwnership(UUID commerceId);
 
     void ifCommerceNameAlreadyExistsThrowException(String name);
 

--- a/src/main/java/com/rescuebites/api/commerce/repositories/ICommerceRepository.java
+++ b/src/main/java/com/rescuebites/api/commerce/repositories/ICommerceRepository.java
@@ -2,6 +2,7 @@ package com.rescuebites.api.commerce.repositories;
 
 import com.rescuebites.api.commerce.data.enums.CommerceTypeEnum;
 import com.rescuebites.api.commerce.data.models.Commerce;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,6 +16,7 @@ import java.util.UUID;
 @Repository
 public interface ICommerceRepository extends JpaRepository<Commerce, UUID> {
 
+    @Cacheable(value = "commerceById", key = "#commerceId")
     Optional<Commerce> findByCommerceIdAndDeletedFalse(UUID commerceId);
 
     boolean existsByNameAndDeletedFalse(String name);

--- a/src/main/java/com/rescuebites/api/commerce/repositories/ICommerceTypeRepository.java
+++ b/src/main/java/com/rescuebites/api/commerce/repositories/ICommerceTypeRepository.java
@@ -2,6 +2,7 @@ package com.rescuebites.api.commerce.repositories;
 
 import com.rescuebites.api.commerce.data.enums.CommerceTypeEnum;
 import com.rescuebites.api.commerce.data.models.CommerceType;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,6 +12,7 @@ import java.util.UUID;
 @Repository
 public interface ICommerceTypeRepository extends JpaRepository<CommerceType, UUID> {
 
+    @Cacheable(value = "commerceTypes", key = "#name")
     Optional<CommerceType> findByName(CommerceTypeEnum name);
 }
 

--- a/src/main/java/com/rescuebites/api/commerce/services/implementations/CommerceServiceImpl.java
+++ b/src/main/java/com/rescuebites/api/commerce/services/implementations/CommerceServiceImpl.java
@@ -1,6 +1,7 @@
 package com.rescuebites.api.commerce.services.implementations;
 
 import com.rescuebites.api.commerce.controllers.requests.CreateCommerceRequest;
+import com.rescuebites.api.commerce.controllers.requests.UpdateCommerceCredentialsRequest;
 import com.rescuebites.api.commerce.controllers.requests.UpdateCommerceRequest;
 import com.rescuebites.api.commerce.controllers.responses.CommerceResponse;
 import com.rescuebites.api.commerce.data.mappers.CommerceMapper;
@@ -9,14 +10,11 @@ import com.rescuebites.api.commerce.data.models.CommerceType;
 import com.rescuebites.api.commerce.facades.interfaces.ICommerceFacade;
 import com.rescuebites.api.commerce.repositories.ICommerceRepository;
 import com.rescuebites.api.commerce.services.interfaces.ICommerceService;
-import com.rescuebites.api.exceptions.custom_exceptions.ResourceNotFoundException;
 import com.rescuebites.api.security.utils.SecurityUtils;
 import com.rescuebites.api.shared.Image;
 import com.rescuebites.api.shared.facades.interfaces.IImageFacade;
 import com.rescuebites.api.users.data.models.User;
 import com.rescuebites.api.users.events.EmailUpdatedEvent;
-import com.rescuebites.api.users.facades.interfaces.IUserFacade;
-import com.rescuebites.api.users.services.interfaces.IEmailService;
 import com.rescuebites.api.users.services.interfaces.ITokenService;
 import com.rescuebites.api.users.services.interfaces.IUserService;
 import jakarta.transaction.Transactional;
@@ -46,7 +44,6 @@ public class CommerceServiceImpl implements ICommerceService {
     @Transactional
     public void createCommerce(CreateCommerceRequest createCommerceRequest, MultipartFile[] images) {
         User user = userService.findByIdOrThrowException(createCommerceRequest.getUserId());
-        SecurityUtils.validateOwnership(user.getEmail());
 
         commerceFacade.ifCommerceNameAlreadyExistsThrowException(createCommerceRequest.getName());
 
@@ -60,7 +57,7 @@ public class CommerceServiceImpl implements ICommerceService {
 
     @Override
     public CommerceResponse getCommerceById(UUID commerceId) {
-        Commerce commerce = findCommerceByIdOrThrowException(commerceId);
+        Commerce commerce = commerceFacade.findCommerceByIdOrThrowException(commerceId);
         SecurityUtils.validateOwnership(commerce.getUser().getEmail());
 
         return CommerceMapper.toCommerceResponse(commerce);
@@ -69,7 +66,7 @@ public class CommerceServiceImpl implements ICommerceService {
     @Override
     @Transactional
     public void updateCommerce(UUID commerceId, UpdateCommerceRequest updateCommerceRequest, MultipartFile[] images) {
-        Commerce commerce = findCommerceByIdOrThrowException(commerceId);
+        Commerce commerce = commerceFacade.findCommerceByIdOrThrowException(commerceId);
         User user = commerce.getUser();
         SecurityUtils.validateOwnership(user.getEmail());
 
@@ -95,7 +92,7 @@ public class CommerceServiceImpl implements ICommerceService {
     @Override
     @Transactional
     public void deleteCommerce(UUID commerceId) {
-        Commerce commerce = findCommerceByIdOrThrowException(commerceId);
+        Commerce commerce = commerceFacade.findCommerceByIdOrThrowException(commerceId);
         User user = commerce.getUser();
         SecurityUtils.validateOwnership(user.getEmail());
         List<Image> currentImages = commerce.getImages();
@@ -120,13 +117,21 @@ public class CommerceServiceImpl implements ICommerceService {
         commerceRepository.save(commerce);
     }
 
+    @Override
+    @Transactional
+    public void updateCommerceCredentials(UUID commerceId, UpdateCommerceCredentialsRequest request) {
+        Commerce commerce = commerceFacade.findCommerceByIdOrThrowException(commerceId);
+        SecurityUtils.validateOwnership(commerce.getUser().getEmail());
+
+        commerce.setMercadoPagoAccessToken(request.getMercadoPagoAccessToken());
+        commerce.setMercadoPagoWebhookSecret(request.getMercadoPagoWebhookSecret());
+        commerce.setUpdatedAt(LocalDateTime.now());
+
+        commerceRepository.save(commerce);
+    }
+
     private void sendEmailChangeConfirmation(User user) {
         UUID tokenId = tokenService.findLatestTokenByUser(user).getTokenId();
         eventPublisher.publishEvent(new EmailUpdatedEvent(user, tokenId));
-    }
-
-    private Commerce findCommerceByIdOrThrowException(UUID commerceId) {
-        return commerceRepository.findByCommerceIdAndDeletedFalse(commerceId)
-                .orElseThrow(() -> new ResourceNotFoundException("Commerce", "id", commerceId));
     }
 }

--- a/src/main/java/com/rescuebites/api/commerce/services/interfaces/ICommerceService.java
+++ b/src/main/java/com/rescuebites/api/commerce/services/interfaces/ICommerceService.java
@@ -16,4 +16,6 @@ public interface ICommerceService {
     void updateCommerce(UUID commerceId, UpdateCommerceRequest updateCommerceRequest, MultipartFile[] images);
 
     void deleteCommerce(UUID commerceId);
+
+    void updateCommerceCredentials(UUID commerceId, com.rescuebites.api.commerce.controllers.requests.UpdateCommerceCredentialsRequest request);
 }

--- a/src/main/java/com/rescuebites/api/order/controllers/implementations/CommerceOrderControllerImpl.java
+++ b/src/main/java/com/rescuebites/api/order/controllers/implementations/CommerceOrderControllerImpl.java
@@ -1,0 +1,40 @@
+package com.rescuebites.api.order.controllers.implementations;
+
+import com.rescuebites.api.order.controllers.interfaces.ICommerceOrderController;
+import com.rescuebites.api.order.controllers.requests.UpdateOrderStatusRequest;
+import com.rescuebites.api.order.controllers.responses.OrderResponse;
+import com.rescuebites.api.order.data.enums.OrderStatus;
+import com.rescuebites.api.order.services.interfaces.ICommerceOrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+public class CommerceOrderControllerImpl implements ICommerceOrderController {
+
+    private final ICommerceOrderService commerceOrderService;
+
+    @Override
+    public Page<OrderResponse> getCommerceOrders(UUID commerceId, Pageable pageable) {
+        return commerceOrderService.getCommerceOrders(commerceId, pageable);
+    }
+
+    @Override
+    public Page<OrderResponse> getCommerceOrdersByStatus(UUID commerceId, OrderStatus status, Pageable pageable) {
+        return commerceOrderService.getCommerceOrdersByStatus(commerceId, status, pageable);
+    }
+
+    @Override
+    public OrderResponse getCommerceOrderById(UUID commerceId, UUID orderId) {
+        return commerceOrderService.getCommerceOrderById(commerceId, orderId);
+    }
+
+    @Override
+    public void updateOrderStatus(UUID commerceId, UUID orderId, UpdateOrderStatusRequest request) {
+        commerceOrderService.updateOrderStatus(commerceId, orderId, request.newStatus(), request.reason());
+    }
+}

--- a/src/main/java/com/rescuebites/api/order/controllers/interfaces/ICommerceOrderController.java
+++ b/src/main/java/com/rescuebites/api/order/controllers/interfaces/ICommerceOrderController.java
@@ -1,0 +1,99 @@
+package com.rescuebites.api.order.controllers.interfaces;
+
+import com.rescuebites.api.order.controllers.requests.UpdateOrderStatusRequest;
+import com.rescuebites.api.order.controllers.responses.OrderResponse;
+import com.rescuebites.api.order.data.enums.OrderStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+
+@RequestMapping("/api/v1/commerces/{commerceId}/orders")
+@Tag(name = "Orders - Commerce", description = "Gestión de pedidos del comercio")
+public interface ICommerceOrderController {
+
+    @GetMapping
+    @Operation(
+            summary = "Listar pedidos del comercio",
+            description = "Retorna todos los pedidos del comercio ordenados por fecha (más reciente primero)"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Pedidos obtenidos exitosamente"),
+            @ApiResponse(responseCode = "404", description = "Comercio no encontrado")
+    })
+    Page<OrderResponse> getCommerceOrders(
+            @Parameter(description = "ID del comercio", required = true)
+            @PathVariable UUID commerceId,
+
+            @Parameter(description = "Parámetros de paginación")
+            Pageable pageable
+    );
+
+    @GetMapping("/status/{status}")
+    @Operation(
+            summary = "Listar pedidos por estado",
+            description = "Retorna pedidos del comercio filtrados por estado"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Pedidos obtenidos exitosamente"),
+            @ApiResponse(responseCode = "404", description = "Comercio no encontrado")
+    })
+    Page<OrderResponse> getCommerceOrdersByStatus(
+            @Parameter(description = "ID del comercio", required = true)
+            @PathVariable UUID commerceId,
+
+            @Parameter(description = "Estado del pedido", required = true)
+            @PathVariable OrderStatus status,
+
+            @Parameter(description = "Parámetros de paginación")
+            Pageable pageable
+    );
+
+    @GetMapping("/{orderId}")
+    @Operation(
+            summary = "Obtener detalle de un pedido",
+            description = "Retorna información detallada de un pedido específico del comercio"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Pedido obtenido exitosamente"),
+            @ApiResponse(responseCode = "404", description = "Pedido no encontrado")
+    })
+    OrderResponse getCommerceOrderById(
+            @Parameter(description = "ID del comercio", required = true)
+            @PathVariable UUID commerceId,
+
+            @Parameter(description = "ID del pedido", required = true)
+            @PathVariable UUID orderId
+    );
+
+    @PatchMapping("/{orderId}/status")
+    @ResponseStatus(NO_CONTENT)
+    @Operation(
+            summary = "Actualizar estado del pedido",
+            description = "Cambia el estado de un pedido (ej: de PENDING a CONFIRMED, de CONFIRMED a PREPARING, etc.)"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Estado actualizado exitosamente"),
+            @ApiResponse(responseCode = "400", description = "Transición de estado inválida"),
+            @ApiResponse(responseCode = "404", description = "Pedido no encontrado")
+    })
+    void updateOrderStatus(
+            @Parameter(description = "ID del comercio", required = true)
+            @PathVariable UUID commerceId,
+
+            @Parameter(description = "ID del pedido", required = true)
+            @PathVariable UUID orderId,
+
+            @Parameter(description = "Nuevo estado", required = true)
+            @RequestBody @Valid UpdateOrderStatusRequest request
+    );
+}

--- a/src/main/java/com/rescuebites/api/order/services/implementations/CommerceOrderServiceImpl.java
+++ b/src/main/java/com/rescuebites/api/order/services/implementations/CommerceOrderServiceImpl.java
@@ -1,0 +1,87 @@
+package com.rescuebites.api.order.services.implementations;
+
+import com.rescuebites.api.commerce.facades.interfaces.ICommerceFacade;
+import com.rescuebites.api.exceptions.custom_exceptions.ValidationException;
+import com.rescuebites.api.order.controllers.responses.OrderResponse;
+import com.rescuebites.api.order.data.enums.OrderStatus;
+import com.rescuebites.api.order.data.mappers.OrderMapper;
+import com.rescuebites.api.order.data.models.Order;
+import com.rescuebites.api.order.facades.interfaces.IOrderValidationFacade;
+import com.rescuebites.api.order.repositories.IOrderRepository;
+import com.rescuebites.api.order.services.interfaces.ICommerceOrderService;
+import com.rescuebites.api.order.utils.OrderStatusValidator;
+import com.rescuebites.api.shared.services.interfaces.IWhatsAppService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CommerceOrderServiceImpl implements ICommerceOrderService {
+
+    private final IOrderRepository orderRepository;
+    private final IOrderValidationFacade orderValidationFacade;
+    private final IWhatsAppService whatsAppService;
+    private final ICommerceFacade commerceFacade;
+
+    @Override
+    @Transactional
+    public Page<OrderResponse> getCommerceOrders(UUID commerceId, Pageable pageable) {
+        commerceFacade.validateCommerceOwnership(commerceId);
+        Page<Order> orders = orderRepository.findByCommerceId(commerceId, pageable);
+        return orders.map(OrderMapper::toOrderResponse);
+    }
+
+    @Override
+    @Transactional
+    public Page<OrderResponse> getCommerceOrdersByStatus(UUID commerceId, OrderStatus status, Pageable pageable) {
+        commerceFacade.validateCommerceOwnership(commerceId);
+        Page<Order> orders = orderRepository.findByCommerceIdAndStatus(commerceId, status, pageable);
+        return orders.map(OrderMapper::toOrderResponse);
+    }
+
+    @Override
+    @Transactional
+    public OrderResponse getCommerceOrderById(UUID commerceId, UUID orderId) {
+        commerceFacade.validateCommerceOwnership(commerceId);
+        Order order = orderValidationFacade.findOrderByIdAndCommerceId(orderId, commerceId);
+
+        return OrderMapper.toOrderResponse(order);
+    }
+
+    @Override
+    @Transactional
+    public void updateOrderStatus(UUID commerceId, UUID orderId, OrderStatus newStatus, String reason) {
+        commerceFacade.validateCommerceOwnership(commerceId);
+        Order order = orderValidationFacade.findOrderByIdAndCommerceId(orderId, commerceId);
+
+        OrderStatusValidator.validateStatusTransition(order.getStatus(), newStatus);
+
+        if (newStatus == OrderStatus.CANCELLED && (reason == null || reason.isBlank())) {
+            throw new ValidationException("El motivo de cancelación es obligatorio");
+        }
+
+        order.setStatus(newStatus);
+        applyStatusTimestamp(order, newStatus, reason);
+
+        orderRepository.save(order);
+        whatsAppService.notifyClientOrderStatusChange(order);
+    }
+
+    private void applyStatusTimestamp(Order order, OrderStatus newStatus, String reason) {
+        switch (newStatus) {
+            case CONFIRMED -> order.setConfirmedAt(LocalDateTime.now());
+            case COMPLETED -> order.setCompletedAt(LocalDateTime.now());
+            case CANCELLED -> {
+                order.setCancelledAt(LocalDateTime.now());
+                order.setCancellationReason(reason);
+            }
+            default -> {} // PENDING, PREPARING, READY no tienen timestamp específico
+        }
+    }
+}

--- a/src/main/java/com/rescuebites/api/order/services/interfaces/ICommerceOrderService.java
+++ b/src/main/java/com/rescuebites/api/order/services/interfaces/ICommerceOrderService.java
@@ -1,0 +1,19 @@
+package com.rescuebites.api.order.services.interfaces;
+
+import com.rescuebites.api.order.controllers.responses.OrderResponse;
+import com.rescuebites.api.order.data.enums.OrderStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.UUID;
+
+public interface ICommerceOrderService {
+
+    Page<OrderResponse> getCommerceOrders(UUID commerceId, Pageable pageable);
+
+    Page<OrderResponse> getCommerceOrdersByStatus(UUID commerceId, OrderStatus status, Pageable pageable);
+
+    OrderResponse getCommerceOrderById(UUID commerceId, UUID orderId);
+
+    void updateOrderStatus(UUID commerceId, UUID orderId, OrderStatus newStatus, String reason);
+}


### PR DESCRIPTION
Implementé el módulo completo de pedidos para comercios que permite:
- Listar todos los pedidos del comercio con paginación
- Filtrar pedidos por estado (PENDING, CONFIRMED, PREPARING, READY, COMPLETED, CANCELLED)
- Consultar detalle de un pedido específico
- Actualizar el estado del pedido (máquina de estados validada)
- Gestionar credenciales de Mercado Pago

**Issues Cerradas**
Closes #38
Closes #40 
Closes #41

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/rescuebites/rescuebites-api/50)
<!-- GitContextEnd -->