### PR TITLE
Gestión de horarios de atención y disponibilidad de comercios

### DIFF
--- a/src/main/java/com/rescuebites/api/cart/facades/implementations/CartValidationFacade.java
+++ b/src/main/java/com/rescuebites/api/cart/facades/implementations/CartValidationFacade.java
@@ -5,6 +5,9 @@ import com.rescuebites.api.cart.facades.interfaces.ICartValidationFacade;
 import com.rescuebites.api.cart.repositories.ICartRepository;
 import com.rescuebites.api.client.data.models.Client;
 import com.rescuebites.api.client.repositories.IClientRepository;
+import com.rescuebites.api.commerce.data.enums.CommerceScheduleStatus;
+import com.rescuebites.api.commerce.data.models.Commerce;
+import com.rescuebites.api.commerce.utils.BusinessHoursUtils;
 import com.rescuebites.api.exceptions.custom_exceptions.ResourceNotFoundException;
 import com.rescuebites.api.exceptions.custom_exceptions.UnauthorizedException;
 import com.rescuebites.api.exceptions.custom_exceptions.ValidationException;
@@ -13,6 +16,7 @@ import com.rescuebites.api.product.repositories.IProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Service
@@ -60,6 +64,18 @@ public class CartValidationFacade implements ICartValidationFacade {
     public void validateCartBelongsToClient(Cart cart, UUID clientId) {
         if (!cart.getClient().getClientId().equals(clientId)) {
             throw new UnauthorizedException("Este carrito no pertenece al cliente autenticado");
+        }
+    }
+
+    @Override
+    public void validateCommerceNotClosedForDay(Commerce commerce) {
+        CommerceScheduleStatus status = BusinessHoursUtils.getCommerceStatus(
+                commerce, LocalDateTime.now());
+
+        if (status.isClosedForDay()) {
+            throw new ValidationException(
+                    "El comercio '" + commerce.getName() + "' está cerrado por hoy. " +
+                            "No es posible agregar productos a tu carrito en este momento");
         }
     }
 }

--- a/src/main/java/com/rescuebites/api/cart/facades/interfaces/ICartValidationFacade.java
+++ b/src/main/java/com/rescuebites/api/cart/facades/interfaces/ICartValidationFacade.java
@@ -2,6 +2,7 @@ package com.rescuebites.api.cart.facades.interfaces;
 
 import com.rescuebites.api.cart.data.models.Cart;
 import com.rescuebites.api.client.data.models.Client;
+import com.rescuebites.api.commerce.data.models.Commerce;
 import com.rescuebites.api.product.data.models.Product;
 
 import java.util.UUID;
@@ -17,4 +18,6 @@ public interface ICartValidationFacade {
     void validateStockAvailability(Product product, Integer requestedQuantity);
 
     void validateCartBelongsToClient(Cart cart, UUID clientId);
+
+    void validateCommerceNotClosedForDay(Commerce commerce);
 }

--- a/src/main/java/com/rescuebites/api/cart/services/implementations/CartServiceImpl.java
+++ b/src/main/java/com/rescuebites/api/cart/services/implementations/CartServiceImpl.java
@@ -64,6 +64,8 @@ public class CartServiceImpl implements ICartService {
 
         Product product = cartValidationFacade.findActiveProductById(request.productId());
         cartValidationFacade.validateStockAvailability(product, request.quantity());
+        cartValidationFacade.validateCommerceNotClosedForDay(product.getCommerce());
+
         Cart cart = cartValidationFacade.findOrCreateCartByClient(client);
 
         cartItemRepository

--- a/src/main/java/com/rescuebites/api/commerce/controllers/requests/BusinessHoursRequest.java
+++ b/src/main/java/com/rescuebites/api/commerce/controllers/requests/BusinessHoursRequest.java
@@ -1,0 +1,32 @@
+package com.rescuebites.api.commerce.controllers.requests;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BusinessHoursRequest {
+
+    @NotNull(message = "El día de la semana es obligatorio")
+    private DayOfWeek dayOfWeek;
+
+    private boolean closed;
+
+    // Hora de apertura (mañana o turno único)
+    private LocalTime openTime;
+
+    // Hora de cierre (mañana o turno único)
+    private LocalTime closeTime;
+
+    // Hora de apertura del turno tarde (opcional)
+    private LocalTime afternoonOpenTime;
+
+    // Hora de cierre del turno tarde (opcional)
+    private LocalTime afternoonCloseTime;
+}

--- a/src/main/java/com/rescuebites/api/commerce/controllers/requests/CreateCommerceRequest.java
+++ b/src/main/java/com/rescuebites/api/commerce/controllers/requests/CreateCommerceRequest.java
@@ -1,6 +1,7 @@
 package com.rescuebites.api.commerce.controllers.requests;
 
 import com.rescuebites.api.commerce.data.enums.CommerceTypeEnum;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -30,8 +31,9 @@ public class CreateCommerceRequest {
     @NotEmpty(message = "Debe seleccionar al menos un tipo de comercio")
     private List<CommerceTypeEnum> commerceTypes;
 
-    @NotBlank(message = "El horario es obligatorio")
-    private String openingHours;
+    @NotEmpty(message = "Debe definir al menos un horario de atención")
+    @Valid
+    private List<BusinessHoursRequest> businessHours;
 
     @NotBlank(message = "La dirección es obligatoria")
     private String address;

--- a/src/main/java/com/rescuebites/api/commerce/controllers/requests/UpdateCommerceRequest.java
+++ b/src/main/java/com/rescuebites/api/commerce/controllers/requests/UpdateCommerceRequest.java
@@ -1,6 +1,7 @@
 package com.rescuebites.api.commerce.controllers.requests;
 
 import com.rescuebites.api.commerce.data.enums.CommerceTypeEnum;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -22,7 +23,8 @@ public class UpdateCommerceRequest {
 
     private List<CommerceTypeEnum> commerceTypes;
 
-    private String openingHours;
+    @Valid
+    private List<BusinessHoursRequest> businessHours;
 
     private String address;
 

--- a/src/main/java/com/rescuebites/api/commerce/controllers/responses/BusinessHoursResponse.java
+++ b/src/main/java/com/rescuebites/api/commerce/controllers/responses/BusinessHoursResponse.java
@@ -1,0 +1,13 @@
+package com.rescuebites.api.commerce.controllers.responses;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+public record BusinessHoursResponse(
+        DayOfWeek dayOfWeek,
+        boolean closed,
+        LocalTime openTime,
+        LocalTime closeTime,
+        LocalTime afternoonOpenTime,
+        LocalTime afternoonCloseTime
+) {}

--- a/src/main/java/com/rescuebites/api/commerce/controllers/responses/CommerceResponse.java
+++ b/src/main/java/com/rescuebites/api/commerce/controllers/responses/CommerceResponse.java
@@ -2,16 +2,14 @@ package com.rescuebites.api.commerce.controllers.responses;
 
 import com.rescuebites.api.client.controllers.responses.ImageResponse;
 import com.rescuebites.api.commerce.data.enums.CommerceTypeEnum;
-import com.rescuebites.api.users.controllers.responses.UserResponse;
 
 import java.util.List;
-import java.util.UUID;
 
 public record CommerceResponse(
         String name,
         String description,
         List<CommerceTypeEnum> commerceTypes,
-        String openingHours,
+        List<BusinessHoursResponse> businessHours,
         String address,
         String locality,
         String phone,

--- a/src/main/java/com/rescuebites/api/commerce/data/enums/CommerceScheduleStatus.java
+++ b/src/main/java/com/rescuebites/api/commerce/data/enums/CommerceScheduleStatus.java
@@ -1,0 +1,35 @@
+package com.rescuebites.api.commerce.data.enums;
+
+import java.time.LocalTime;
+
+public record CommerceScheduleStatus(
+        Status status,
+        LocalTime nextOpenTime,
+        LocalTime nextCloseTime
+) {
+    public enum Status {
+        OPEN,
+        CLOSED_REOPENS_LATER,
+        CLOSED_FOR_DAY
+    }
+
+    public static CommerceScheduleStatus open(LocalTime closeTime) {
+        return new CommerceScheduleStatus(Status.OPEN, null, closeTime);
+    }
+
+    public static CommerceScheduleStatus closedReopensLater(LocalTime nextOpen, LocalTime nextClose) {
+        return new CommerceScheduleStatus(Status.CLOSED_REOPENS_LATER, nextOpen, nextClose);
+    }
+
+    public static CommerceScheduleStatus closedForDay() {
+        return new CommerceScheduleStatus(Status.CLOSED_FOR_DAY, null, null);
+    }
+
+    public boolean isOpen() {
+        return status == Status.OPEN;
+    }
+
+    public boolean isClosedForDay() {
+        return status == Status.CLOSED_FOR_DAY;
+    }
+}

--- a/src/main/java/com/rescuebites/api/commerce/data/mappers/BusinessHoursMapper.java
+++ b/src/main/java/com/rescuebites/api/commerce/data/mappers/BusinessHoursMapper.java
@@ -1,0 +1,49 @@
+package com.rescuebites.api.commerce.data.mappers;
+
+import com.rescuebites.api.commerce.controllers.requests.BusinessHoursRequest;
+import com.rescuebites.api.commerce.controllers.responses.BusinessHoursResponse;
+import com.rescuebites.api.commerce.data.models.BusinessHours;
+import com.rescuebites.api.commerce.data.models.Commerce;
+
+import java.util.Collection;
+import java.util.List;
+
+public class BusinessHoursMapper {
+
+    private BusinessHoursMapper() {}
+
+    public static BusinessHours toBusinessHours(BusinessHoursRequest request, Commerce commerce) {
+        return BusinessHours.builder()
+                .commerce(commerce)
+                .dayOfWeek(request.getDayOfWeek())
+                .closed(request.isClosed())
+                .openTime(request.getOpenTime())
+                .closeTime(request.getCloseTime())
+                .afternoonOpenTime(request.getAfternoonOpenTime())
+                .afternoonCloseTime(request.getAfternoonCloseTime())
+                .build();
+    }
+
+    public static List<BusinessHours> toBusinessHoursList(List<BusinessHoursRequest> requests, Commerce commerce) {
+        return requests.stream()
+                .map(request -> toBusinessHours(request, commerce))
+                .toList();
+    }
+
+    public static BusinessHoursResponse toBusinessHoursResponse(BusinessHours businessHours) {
+        return new BusinessHoursResponse(
+                businessHours.getDayOfWeek(),
+                businessHours.isClosed(),
+                businessHours.getOpenTime(),
+                businessHours.getCloseTime(),
+                businessHours.getAfternoonOpenTime(),
+                businessHours.getAfternoonCloseTime()
+        );
+    }
+
+    public static List<BusinessHoursResponse> toBusinessHoursResponseList(Collection<BusinessHours> businessHours) {
+        return businessHours.stream()
+                .map(BusinessHoursMapper::toBusinessHoursResponse)
+                .toList();
+    }
+}

--- a/src/main/java/com/rescuebites/api/commerce/data/mappers/CommerceMapper.java
+++ b/src/main/java/com/rescuebites/api/commerce/data/mappers/CommerceMapper.java
@@ -1,21 +1,23 @@
 package com.rescuebites.api.commerce.data.mappers;
 
 import com.rescuebites.api.client.data.mappers.ImageMapper;
+import com.rescuebites.api.commerce.controllers.requests.BusinessHoursRequest;
 import com.rescuebites.api.commerce.controllers.requests.CreateCommerceRequest;
 import com.rescuebites.api.commerce.controllers.requests.UpdateCommerceRequest;
 import com.rescuebites.api.commerce.controllers.responses.CommercePublicResponse;
 import com.rescuebites.api.commerce.controllers.responses.CommerceResponse;
+import com.rescuebites.api.commerce.data.models.BusinessHours;
 import com.rescuebites.api.commerce.data.models.Commerce;
 import com.rescuebites.api.commerce.data.models.CommerceType;
 import com.rescuebites.api.shared.Image;
 import com.rescuebites.api.users.data.models.User;
 import org.springframework.stereotype.Component;
 
+import java.time.DayOfWeek;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
-
-import static com.rescuebites.api.users.data.mappers.UserMapper.toUserResponse;
 
 @Component
 public class CommerceMapper {
@@ -32,11 +34,15 @@ public class CommerceMapper {
                 .name(request.getName())
                 .description(request.getDescription())
                 .commerceTypes(commerceTypes)
-                .openingHours(request.getOpeningHours())
                 .address(request.getAddress())
                 .locality(request.getLocality())
                 .phone(request.getPhone())
                 .build();
+
+        // Asociar horarios al comercio
+        List<BusinessHours> businessHours = BusinessHoursMapper.toBusinessHoursList(
+                request.getBusinessHours(), commerce);
+        commerce.getBusinessHours().addAll(businessHours);
 
         // Asociar las imágenes al comercio
         images.forEach(image -> image.setCommerce(commerce));
@@ -52,7 +58,7 @@ public class CommerceMapper {
                 commerce.getCommerceTypes().stream()
                         .map(CommerceType::getName)
                         .collect(Collectors.toList()),
-                commerce.getOpeningHours(),
+                BusinessHoursMapper.toBusinessHoursResponseList(commerce.getBusinessHours()),
                 commerce.getAddress(),
                 commerce.getLocality(),
                 commerce.getPhone(),
@@ -87,8 +93,25 @@ public class CommerceMapper {
         if (commerceTypes != null && !commerceTypes.isEmpty()) {
             commerce.setCommerceTypes(commerceTypes);
         }
-        if (request.getOpeningHours() != null) {
-            commerce.setOpeningHours(request.getOpeningHours());
+        if (request.getBusinessHours() != null && !request.getBusinessHours().isEmpty()) {
+            Map<DayOfWeek, BusinessHours> existingByDay = commerce.getBusinessHours().stream()
+                    .collect(Collectors.toMap(BusinessHours::getDayOfWeek, bh -> bh));
+
+            for (BusinessHoursRequest bhRequest : request.getBusinessHours()) {
+                BusinessHours existing = existingByDay.get(bhRequest.getDayOfWeek());
+                if (existing != null) {
+                    // Actualizar el día existente
+                    existing.setClosed(bhRequest.isClosed());
+                    existing.setOpenTime(bhRequest.getOpenTime());
+                    existing.setCloseTime(bhRequest.getCloseTime());
+                    existing.setAfternoonOpenTime(bhRequest.getAfternoonOpenTime());
+                    existing.setAfternoonCloseTime(bhRequest.getAfternoonCloseTime());
+                } else {
+                    // Agregar nuevo día
+                    commerce.getBusinessHours().add(
+                            BusinessHoursMapper.toBusinessHours(bhRequest, commerce));
+                }
+            }
         }
         if (request.getAddress() != null) {
             commerce.setAddress(request.getAddress());

--- a/src/main/java/com/rescuebites/api/commerce/data/models/BusinessHours.java
+++ b/src/main/java/com/rescuebites/api/commerce/data/models/BusinessHours.java
@@ -1,0 +1,82 @@
+package com.rescuebites.api.commerce.data.models;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.UUID;
+
+@Entity(name = "business_hours")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "businessHoursId")
+@ToString(exclude = "commerce")
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"commerce_id", "day_of_week"}))
+public class BusinessHours {
+
+    @Id
+    @Column(name = "business_hours_id")
+    @Builder.Default
+    private UUID businessHoursId = UUID.randomUUID();
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "commerce_id", nullable = false)
+    private Commerce commerce;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "day_of_week", nullable = false)
+    private DayOfWeek dayOfWeek;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private boolean closed = false;
+
+    // Horario de apertura (mañana o único turno)
+    @Column(name = "open_time")
+    private LocalTime openTime;
+
+    // Horario de cierre (mañana o único turno)
+    @Column(name = "close_time")
+    private LocalTime closeTime;
+
+    // Horario de apertura del turno tarde (nullable = turno continuo)
+    @Column(name = "afternoon_open_time")
+    private LocalTime afternoonOpenTime;
+
+    // Horario de cierre del turno tarde (nullable = turno continuo)
+    @Column(name = "afternoon_close_time")
+    private LocalTime afternoonCloseTime;
+
+    public boolean hasSplitSchedule() {
+        return afternoonOpenTime != null && afternoonCloseTime != null;
+    }
+
+     // Verifica si una hora dada cae dentro del horario de atención
+    public boolean isOpenAt(LocalTime time) {
+        if (closed || openTime == null || closeTime == null) {
+            return false;
+        }
+
+        boolean inMorningShift = !time.isBefore(openTime) && time.isBefore(closeTime);
+
+        if (hasSplitSchedule()) {
+            boolean inAfternoonShift = !time.isBefore(afternoonOpenTime) && time.isBefore(afternoonCloseTime);
+            return inMorningShift || inAfternoonShift;
+        }
+
+        return inMorningShift;
+    }
+
+    public boolean willReopenLater(LocalTime currentTime) {
+        if (closed || !hasSplitSchedule()) {
+            return false;
+        }
+
+        // Está entre el cierre de la mañana y la apertura de la tarde
+        return !currentTime.isBefore(closeTime) && currentTime.isBefore(afternoonOpenTime);
+    }
+}

--- a/src/main/java/com/rescuebites/api/commerce/data/models/Commerce.java
+++ b/src/main/java/com/rescuebites/api/commerce/data/models/Commerce.java
@@ -14,7 +14,9 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 @Entity(name = "commerces")
@@ -49,9 +51,9 @@ public class Commerce {
     @Builder.Default
     private List<CommerceType> commerceTypes = new ArrayList<>();
 
-    @NotBlank(message = "El horario es obligatorio")
-    @Column(name = "opening_hours", nullable = false)
-    private String openingHours;
+    @OneToMany(mappedBy = "commerce", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    @Builder.Default
+    private Set<BusinessHours> businessHours = new HashSet<>();
 
     @NotBlank(message = "La dirección es obligatoria")
     @Column(nullable = false)

--- a/src/main/java/com/rescuebites/api/commerce/facades/implementations/CommerceFacade.java
+++ b/src/main/java/com/rescuebites/api/commerce/facades/implementations/CommerceFacade.java
@@ -1,5 +1,6 @@
 package com.rescuebites.api.commerce.facades.implementations;
 
+import com.rescuebites.api.commerce.controllers.requests.BusinessHoursRequest;
 import com.rescuebites.api.commerce.controllers.requests.UpdateCommerceRequest;
 import com.rescuebites.api.commerce.data.enums.CommerceTypeEnum;
 import com.rescuebites.api.commerce.data.models.Commerce;
@@ -19,7 +20,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import java.time.DayOfWeek;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -36,6 +40,12 @@ public class CommerceFacade implements ICommerceFacade {
     @Override
     public Commerce findCommerceByIdOrThrowException(UUID commerceId) {
         return commerceRepository.findByCommerceIdAndDeletedFalse(commerceId)
+                .orElseThrow(() -> new ResourceNotFoundException("Commerce", "id", commerceId));
+    }
+
+    @Override
+    public Commerce findCommerceWithDetailsOrThrowException(UUID commerceId) {
+        return commerceRepository.findByIdWithDetails(commerceId)
                 .orElseThrow(() -> new ResourceNotFoundException("Commerce", "id", commerceId));
     }
 
@@ -64,7 +74,7 @@ public class CommerceFacade implements ICommerceFacade {
         boolean hasAtLeastOneField = StringUtils.hasText(request.getName()) ||
                 StringUtils.hasText(request.getDescription()) ||
                 (request.getCommerceTypes() != null && !request.getCommerceTypes().isEmpty()) ||
-                StringUtils.hasText(request.getOpeningHours()) ||
+                (request.getBusinessHours() != null && !request.getBusinessHours().isEmpty()) ||
                 StringUtils.hasText(request.getAddress()) ||
                 StringUtils.hasText(request.getLocality()) ||
                 StringUtils.hasText(request.getPhone()) ||
@@ -78,8 +88,24 @@ public class CommerceFacade implements ICommerceFacade {
     }
 
     @Override
+    public void validateBusinessHours(List<BusinessHoursRequest> businessHours, boolean requireAllDays) {
+        if (businessHours == null || businessHours.isEmpty()) {
+            return;
+        }
+
+        validateNoDuplicateDays(businessHours);
+
+        if (requireAllDays) {
+            validateAllDaysPresent(businessHours);
+        }
+
+        businessHours.forEach(this::validateSingleBusinessHours);
+    }
+
+    @Override
     public boolean validateAndProcessUpdate(User user, UpdateCommerceRequest request) {
         validateAtLeastOneFieldToUpdate(request);
+        validateBusinessHours(request.getBusinessHours(), false);
 
         boolean emailChanged = userFacade.validateAndCheckEmailChange(user, request.getEmail());
         userFacade.validatePasswordsIfProvided(request.getPassword(), request.getConfirmPassword());
@@ -110,5 +136,75 @@ public class CommerceFacade implements ICommerceFacade {
                 .name(commerceTypeEnum)
                 .build();
         return commerceTypeRepository.save(newType);
+    }
+
+    private void validateNoDuplicateDays(List<BusinessHoursRequest> businessHours) {
+        Set<DayOfWeek> days = new HashSet<>();
+        for (BusinessHoursRequest bh : businessHours) {
+            if (!days.add(bh.getDayOfWeek())) {
+                throw new ValidationException(
+                        "El día " + bh.getDayOfWeek() + " está duplicado en los horarios de atención");
+            }
+        }
+    }
+
+    private void validateAllDaysPresent(List<BusinessHoursRequest> businessHours) {
+        Set<DayOfWeek> providedDays = businessHours.stream()
+                .map(BusinessHoursRequest::getDayOfWeek)
+                .collect(Collectors.toSet());
+
+        if (providedDays.size() != 7) {
+            Set<DayOfWeek> missingDays = new HashSet<>(Set.of(DayOfWeek.values()));
+            missingDays.removeAll(providedDays);
+
+            throw new ValidationException(
+                    "Debe definir el horario de todos los días de la semana. Faltan: " +
+                            missingDays.stream()
+                                    .map(DayOfWeek::name)
+                                    .collect(Collectors.joining(", ")));
+        }
+    }
+
+    private void validateSingleBusinessHours(BusinessHoursRequest bh) {
+        String day = bh.getDayOfWeek().name();
+
+        if (bh.isClosed()) {
+            return;
+        }
+
+        // Si no está cerrado, openTime y closeTime son obligatorios
+        if (bh.getOpenTime() == null || bh.getCloseTime() == null) {
+            throw new ValidationException(
+                    day + ": la hora de apertura y cierre son obligatorias cuando el comercio está abierto");
+        }
+
+        // openTime debe ser anterior a closeTime
+        if (!bh.getOpenTime().isBefore(bh.getCloseTime())) {
+            throw new ValidationException(
+                    day + ": la hora de apertura debe ser anterior a la hora de cierre");
+        }
+
+        // Validaciones del turno tarde
+        boolean hasAfternoonOpen = bh.getAfternoonOpenTime() != null;
+        boolean hasAfternoonClose = bh.getAfternoonCloseTime() != null;
+
+        if (hasAfternoonOpen != hasAfternoonClose) {
+            throw new ValidationException(
+                    day + ": debe definir ambos horarios del turno tarde (apertura y cierre) o ninguno");
+        }
+
+        if (hasAfternoonOpen) {
+            // afternoonOpenTime debe ser posterior a closeTime
+            if (!bh.getAfternoonOpenTime().isAfter(bh.getCloseTime())) {
+                throw new ValidationException(
+                        day + ": la apertura del turno tarde debe ser posterior al cierre del turno mañana");
+            }
+
+            // afternoonOpenTime debe ser anterior a afternoonCloseTime
+            if (!bh.getAfternoonOpenTime().isBefore(bh.getAfternoonCloseTime())) {
+                throw new ValidationException(
+                        day + ": la apertura del turno tarde debe ser anterior al cierre del turno tarde");
+            }
+        }
     }
 }

--- a/src/main/java/com/rescuebites/api/commerce/facades/interfaces/ICommerceFacade.java
+++ b/src/main/java/com/rescuebites/api/commerce/facades/interfaces/ICommerceFacade.java
@@ -1,5 +1,6 @@
 package com.rescuebites.api.commerce.facades.interfaces;
 
+import com.rescuebites.api.commerce.controllers.requests.BusinessHoursRequest;
 import com.rescuebites.api.commerce.controllers.requests.UpdateCommerceRequest;
 import com.rescuebites.api.commerce.data.enums.CommerceTypeEnum;
 import com.rescuebites.api.commerce.data.models.Commerce;
@@ -13,11 +14,15 @@ public interface ICommerceFacade {
 
     Commerce findCommerceByIdOrThrowException(UUID commerceId);
 
+    Commerce findCommerceWithDetailsOrThrowException(UUID commerceId);
+
     void validateCommerceOwnership(UUID commerceId);
 
     void ifCommerceNameAlreadyExistsThrowException(String name);
 
     List<CommerceType> getOrCreateCommerceTypes(List<CommerceTypeEnum> commerceTypeEnums);
+
+    void validateBusinessHours(List<BusinessHoursRequest> businessHours, boolean requireAllDays);
 
     void validateAtLeastOneFieldToUpdate(UpdateCommerceRequest request);
 

--- a/src/main/java/com/rescuebites/api/commerce/repositories/ICommerceRepository.java
+++ b/src/main/java/com/rescuebites/api/commerce/repositories/ICommerceRepository.java
@@ -19,6 +19,11 @@ public interface ICommerceRepository extends JpaRepository<Commerce, UUID> {
     @Cacheable(value = "commerceById", key = "#commerceId")
     Optional<Commerce> findByCommerceIdAndDeletedFalse(UUID commerceId);
 
+    @Query("SELECT c FROM commerces c " +
+            "LEFT JOIN FETCH c.images " +
+            "WHERE c.commerceId = :commerceId AND c.deleted = false")
+    Optional<Commerce> findByIdWithDetails(@Param("commerceId") UUID commerceId);
+
     boolean existsByNameAndDeletedFalse(String name);
 
     Page<Commerce> findByDeletedFalse(Pageable pageable);

--- a/src/main/java/com/rescuebites/api/commerce/services/implementations/CommerceServiceImpl.java
+++ b/src/main/java/com/rescuebites/api/commerce/services/implementations/CommerceServiceImpl.java
@@ -19,8 +19,8 @@ import com.rescuebites.api.users.services.interfaces.ITokenService;
 import com.rescuebites.api.users.services.interfaces.IUserService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
@@ -46,6 +46,7 @@ public class CommerceServiceImpl implements ICommerceService {
         User user = userService.findByIdOrThrowException(createCommerceRequest.getUserId());
 
         commerceFacade.ifCommerceNameAlreadyExistsThrowException(createCommerceRequest.getName());
+        commerceFacade.validateBusinessHours(createCommerceRequest.getBusinessHours(), true);
 
         imageFacade.validateImages(images);
         List<Image> storedProduct = imageFacade.uploadAndSaveImages(images);
@@ -57,8 +58,9 @@ public class CommerceServiceImpl implements ICommerceService {
 
     @Override
     @Transactional
+    @CacheEvict(value = "commerceById", key = "#commerceId")
     public void updateCommerce(UUID commerceId, UpdateCommerceRequest updateCommerceRequest, MultipartFile[] images) {
-        Commerce commerce = commerceFacade.findCommerceByIdOrThrowException(commerceId);
+        Commerce commerce = commerceFacade.findCommerceWithDetailsOrThrowException(commerceId);
         User user = commerce.getUser();
         SecurityUtils.validateOwnership(user.getEmail());
 
@@ -66,7 +68,8 @@ public class CommerceServiceImpl implements ICommerceService {
 
         List<Image> newImages = imageFacade.processImagesIfProvided(commerce.getImages(), images);
 
-        List<CommerceType> commerceTypes = updateCommerceRequest.getCommerceTypes() != null && !updateCommerceRequest.getCommerceTypes().isEmpty()
+        List<CommerceType> commerceTypes = updateCommerceRequest.getCommerceTypes() != null
+                && !updateCommerceRequest.getCommerceTypes().isEmpty()
                 ? commerceFacade.getOrCreateCommerceTypes(updateCommerceRequest.getCommerceTypes())
                 : null;
 
@@ -83,8 +86,9 @@ public class CommerceServiceImpl implements ICommerceService {
 
     @Override
     @Transactional
+    @CacheEvict(value = "commerceById", key = "#commerceId")
     public void deleteCommerce(UUID commerceId) {
-        Commerce commerce = commerceFacade.findCommerceByIdOrThrowException(commerceId);
+        Commerce commerce = commerceFacade.findCommerceWithDetailsOrThrowException(commerceId);
         User user = commerce.getUser();
         SecurityUtils.validateOwnership(user.getEmail());
         List<Image> currentImages = commerce.getImages();
@@ -111,6 +115,7 @@ public class CommerceServiceImpl implements ICommerceService {
 
     @Override
     @Transactional
+    @CacheEvict(value = "commerceById", key = "#commerceId")
     public void updateCommerceCredentials(UUID commerceId, UpdateCommerceCredentialsRequest request) {
         Commerce commerce = commerceFacade.findCommerceByIdOrThrowException(commerceId);
         SecurityUtils.validateOwnership(commerce.getUser().getEmail());

--- a/src/main/java/com/rescuebites/api/commerce/utils/BusinessHoursUtils.java
+++ b/src/main/java/com/rescuebites/api/commerce/utils/BusinessHoursUtils.java
@@ -1,0 +1,59 @@
+package com.rescuebites.api.commerce.utils;
+
+import com.rescuebites.api.commerce.data.enums.CommerceScheduleStatus;
+import com.rescuebites.api.commerce.data.models.BusinessHours;
+import com.rescuebites.api.commerce.data.models.Commerce;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public class BusinessHoursUtils {
+
+    private BusinessHoursUtils() {
+    }
+
+    public static CommerceScheduleStatus getCommerceStatus(Commerce commerce, LocalDateTime dateTime) {
+        BusinessHours hours = findTodayHours(commerce, dateTime.getDayOfWeek());
+
+        if (hours.isClosed()) {
+            return CommerceScheduleStatus.closedForDay();
+        }
+
+        LocalTime currentTime = dateTime.toLocalTime();
+
+        if (hours.isOpenAt(currentTime)) {
+            return CommerceScheduleStatus.open(getCurrentCloseTime(hours, currentTime));
+        }
+
+        return resolveClosedStatus(hours, currentTime);
+    }
+
+    private static BusinessHours findTodayHours(Commerce commerce, DayOfWeek day) {
+        return commerce.getBusinessHours().stream()
+                .filter(bh -> bh.getDayOfWeek().equals(day))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException(
+                        "No se encontró horario para el día " + day + " del comercio '" + commerce.getName() + "'"));
+    }
+
+    private static LocalTime getCurrentCloseTime(BusinessHours hours, LocalTime currentTime) {
+        boolean isInAfternoonShift = hours.hasSplitSchedule()
+                && !currentTime.isBefore(hours.getAfternoonOpenTime());
+        return isInAfternoonShift ? hours.getAfternoonCloseTime() : hours.getCloseTime();
+    }
+
+    private static CommerceScheduleStatus resolveClosedStatus(BusinessHours hours, LocalTime currentTime) {
+        if (currentTime.isBefore(hours.getOpenTime())) {
+            return CommerceScheduleStatus.closedReopensLater(
+                    hours.getOpenTime(), hours.getCloseTime());
+        }
+
+        if (hours.willReopenLater(currentTime)) {
+            return CommerceScheduleStatus.closedReopensLater(
+                    hours.getAfternoonOpenTime(), hours.getAfternoonCloseTime());
+        }
+
+        return CommerceScheduleStatus.closedForDay();
+    }
+}

--- a/src/main/java/com/rescuebites/api/exceptions/CommerceClosedError.java
+++ b/src/main/java/com/rescuebites/api/exceptions/CommerceClosedError.java
@@ -1,0 +1,11 @@
+package com.rescuebites.api.exceptions;
+
+import java.time.LocalTime;
+
+public record CommerceClosedError(
+        int status,
+        String message,
+        String detail,
+        LocalTime nextOpenTime,
+        LocalTime nextCloseTime
+) {}

--- a/src/main/java/com/rescuebites/api/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/rescuebites/api/exceptions/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.rescuebites.api.exceptions;
 import com.rescuebites.api.exceptions.custom_exceptions.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -13,6 +14,17 @@ import org.springframework.web.context.request.WebRequest;
 public class GlobalExceptionHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ApiError> handleDataIntegrity(DataIntegrityViolationException ex) {
+        logger.error("Data integrity error: {}", ex.getMessage());
+        ApiError error = new ApiError(
+                HttpStatus.CONFLICT.value(),
+                "Data integrity error",
+                "No se pudo completar la operación debido a un conflicto con los datos existentes"
+        );
+        return new ResponseEntity<>(error, HttpStatus.CONFLICT);
+    }
 
     // Manejo de excepciones para errores inesperados
     @ExceptionHandler({RuntimeException.class, Exception.class})
@@ -146,5 +158,17 @@ public class GlobalExceptionHandler {
                 ""
         );
         return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(CommerceClosedReopensException.class)
+    public ResponseEntity<CommerceClosedError> handleCommerceClosedReopens(CommerceClosedReopensException ex) {
+        CommerceClosedError error = new CommerceClosedError(
+                HttpStatus.CONFLICT.value(),
+                "Commerce closed",
+                ex.getMessage(),
+                ex.getNextOpenTime(),
+                ex.getNextCloseTime()
+        );
+        return new ResponseEntity<>(error, HttpStatus.CONFLICT);
     }
 }

--- a/src/main/java/com/rescuebites/api/exceptions/custom_exceptions/CommerceClosedReopensException.java
+++ b/src/main/java/com/rescuebites/api/exceptions/custom_exceptions/CommerceClosedReopensException.java
@@ -1,0 +1,24 @@
+package com.rescuebites.api.exceptions.custom_exceptions;
+
+import java.time.LocalTime;
+
+public class CommerceClosedReopensException extends RuntimeException {
+
+    private final LocalTime nextOpenTime;
+    private final LocalTime nextCloseTime;
+
+    public CommerceClosedReopensException(String commerceName, LocalTime nextOpenTime, LocalTime nextCloseTime) {
+        super("El comercio '" + commerceName + "' está cerrado en este momento, " +
+                "pero reabre de " + nextOpenTime + " a " + nextCloseTime);
+        this.nextOpenTime = nextOpenTime;
+        this.nextCloseTime = nextCloseTime;
+    }
+
+    public LocalTime getNextOpenTime() {
+        return nextOpenTime;
+    }
+
+    public LocalTime getNextCloseTime() {
+        return nextCloseTime;
+    }
+}

--- a/src/main/java/com/rescuebites/api/order/controllers/requests/CreateOrderRequest.java
+++ b/src/main/java/com/rescuebites/api/order/controllers/requests/CreateOrderRequest.java
@@ -1,8 +1,11 @@
 package com.rescuebites.api.order.controllers.requests;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+import java.time.LocalTime;
 import java.util.UUID;
 
 public record CreateOrderRequest (
@@ -11,5 +14,10 @@ public record CreateOrderRequest (
     UUID commerceId,
 
     @Size(max = 500, message = "Las notas no pueden superar los 500 caracteres")
-    String notes
+    String notes,
+
+    @JsonFormat(pattern = "HH:mm:ss")
+    @Schema(description = "Horario programado de retiro (requerido si el comercio está cerrado pero reabre más tarde)",
+            example = "15:30:00", nullable = true)
+    LocalTime scheduledPickupTime
 ) {}

--- a/src/main/java/com/rescuebites/api/order/controllers/responses/OrderResponse.java
+++ b/src/main/java/com/rescuebites/api/order/controllers/responses/OrderResponse.java
@@ -5,6 +5,7 @@ import com.rescuebites.api.order.data.enums.PaymentMethod;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -25,5 +26,6 @@ public record OrderResponse(
         PaymentMethod paymentMethod,
         LocalDateTime createdAt,
         LocalDateTime confirmedAt,
+        LocalTime scheduledPickupTime,
         String notes
 ) {}

--- a/src/main/java/com/rescuebites/api/order/data/mappers/OrderMapper.java
+++ b/src/main/java/com/rescuebites/api/order/data/mappers/OrderMapper.java
@@ -56,6 +56,7 @@ public class OrderMapper {
                 order.getPaymentMethod(),
                 order.getCreatedAt(),
                 order.getConfirmedAt(),
+                order.getScheduledPickupTime(),
                 order.getNotes()
         );
     }

--- a/src/main/java/com/rescuebites/api/order/data/models/Order.java
+++ b/src/main/java/com/rescuebites/api/order/data/models/Order.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -72,6 +73,9 @@ public class Order {
 
     @Column(length = 500)
     private String cancellationReason;
+
+    @Column(name = "scheduled_pickup_time")
+    private LocalTime scheduledPickupTime;
 
     @Column(length = 500)
     private String notes;

--- a/src/main/java/com/rescuebites/api/order/facades/implementations/OrderValidationFacade.java
+++ b/src/main/java/com/rescuebites/api/order/facades/implementations/OrderValidationFacade.java
@@ -3,6 +3,10 @@ package com.rescuebites.api.order.facades.implementations;
 import com.rescuebites.api.cart.data.models.Cart;
 import com.rescuebites.api.cart.data.models.CartItem;
 import com.rescuebites.api.cart.repositories.ICartRepository;
+import com.rescuebites.api.commerce.data.enums.CommerceScheduleStatus;
+import com.rescuebites.api.commerce.data.models.Commerce;
+import com.rescuebites.api.commerce.utils.BusinessHoursUtils;
+import com.rescuebites.api.exceptions.custom_exceptions.CommerceClosedReopensException;
 import com.rescuebites.api.exceptions.custom_exceptions.ResourceNotFoundException;
 import com.rescuebites.api.exceptions.custom_exceptions.ValidationException;
 import com.rescuebites.api.order.data.models.Order;
@@ -12,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
@@ -77,12 +82,46 @@ public class OrderValidationFacade implements IOrderValidationFacade {
 
     @Override
     public String generateOrderNumber() {
-        // Formato: ORD-YYYYMMDD-HHMMSS-RANDOM
         LocalDateTime now = LocalDateTime.now();
         String datePart = now.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
         String timePart = now.format(DateTimeFormatter.ofPattern("HHmmss"));
         int randomPart = ThreadLocalRandom.current().nextInt(1000, 9999);
 
         return String.format("ORD-%s-%s-%d", datePart, timePart, randomPart);
+    }
+
+    @Override
+    public void validateCommerceAvailability(Commerce commerce, LocalTime scheduledPickupTime) {
+        CommerceScheduleStatus status = BusinessHoursUtils.getCommerceStatus(
+                commerce, LocalDateTime.now());
+
+        if (status.isOpen()) return;
+
+        if (status.isClosedForDay()) {
+            throwClosedForDayException(commerce);
+        }
+
+        validateScheduledPickupTime(commerce, status, scheduledPickupTime);
+    }
+
+    private void throwClosedForDayException(Commerce commerce) {
+        throw new ValidationException(
+                "El comercio '" + commerce.getName() + "' está cerrado por hoy. " +
+                        "No es posible crear el pedido en este momento");
+    }
+
+    private void validateScheduledPickupTime(Commerce commerce, CommerceScheduleStatus status,
+                                             LocalTime scheduledPickupTime) {
+        if (scheduledPickupTime == null) {
+            throw new CommerceClosedReopensException(
+                    commerce.getName(), status.nextOpenTime(), status.nextCloseTime());
+        }
+
+        if (scheduledPickupTime.isBefore(status.nextOpenTime())
+                || scheduledPickupTime.isAfter(status.nextCloseTime())) {
+            throw new ValidationException(
+                    "El horario programado debe estar entre "
+                            + status.nextOpenTime() + " y " + status.nextCloseTime());
+        }
     }
 }

--- a/src/main/java/com/rescuebites/api/order/facades/interfaces/IOrderValidationFacade.java
+++ b/src/main/java/com/rescuebites/api/order/facades/interfaces/IOrderValidationFacade.java
@@ -1,8 +1,10 @@
 package com.rescuebites.api.order.facades.interfaces;
 
 import com.rescuebites.api.cart.data.models.Cart;
+import com.rescuebites.api.commerce.data.models.Commerce;
 import com.rescuebites.api.order.data.models.Order;
 
+import java.time.LocalTime;
 import java.util.UUID;
 
 public interface IOrderValidationFacade {
@@ -18,6 +20,8 @@ public interface IOrderValidationFacade {
     void validateAllItemsFromSameCommerce(Cart cart, UUID commerceId);
 
     void validateStockForAllItems(Cart cart);
+
+    void validateCommerceAvailability(Commerce commerce, LocalTime scheduledPickupTime);
 
     String generateOrderNumber();
 }

--- a/src/main/java/com/rescuebites/api/order/services/implementations/ClientOrderServiceImpl.java
+++ b/src/main/java/com/rescuebites/api/order/services/implementations/ClientOrderServiceImpl.java
@@ -62,9 +62,17 @@ public class ClientOrderServiceImpl implements IClientOrderService {
 
         validateCartForOrder(cart, request.commerceId());
 
+        // Validar disponibilidad horaria del comercio
+        orderValidationFacade.validateCommerceAvailability(commerce, request.scheduledPickupTime());
+
         PaymentMethod paymentMethod = cart.getSelectedPaymentMethod();
         String orderNumber = orderValidationFacade.generateOrderNumber();
         Order order = OrderMapper.toOrder(client, commerce, orderNumber, request, paymentMethod);
+
+        // Guardar horario programado de retiro si fue proporcionado
+        if (request.scheduledPickupTime() != null) {
+            order.setScheduledPickupTime(request.scheduledPickupTime());
+        }
 
         createOrderItemsAndUpdateStock(order, cart);
         calculateOrderTotals(order);

--- a/src/main/java/com/rescuebites/api/product/controllers/responses/ProductResponse.java
+++ b/src/main/java/com/rescuebites/api/product/controllers/responses/ProductResponse.java
@@ -2,6 +2,7 @@ package com.rescuebites.api.product.controllers.responses;
 
 import com.rescuebites.api.client.controllers.responses.ImageResponse;
 import com.rescuebites.api.client.data.enums.PreferenceType;
+import com.rescuebites.api.commerce.controllers.responses.BusinessHoursResponse;
 import com.rescuebites.api.product.data.enums.ProductCategory;
 import com.rescuebites.api.product.data.enums.ProductCondition;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -26,8 +27,8 @@ public record ProductResponse(
         @Schema(description = "Imágenes del comercio")
         List<ImageResponse> commerceImages,
 
-        @Schema(description = "Horario de apertura del comercio")
-        String commerceOpeningHours,
+        @Schema(description = "Horarios de atención del comercio")
+        List<BusinessHoursResponse> commerceBusinessHours,
 
         @Schema(description = "Nombre del producto")
         String name,

--- a/src/main/java/com/rescuebites/api/product/data/mappers/ProductMapper.java
+++ b/src/main/java/com/rescuebites/api/product/data/mappers/ProductMapper.java
@@ -2,6 +2,7 @@ package com.rescuebites.api.product.data.mappers;
 
 import com.rescuebites.api.client.data.enums.PreferenceType;
 import com.rescuebites.api.client.data.mappers.ImageMapper;
+import com.rescuebites.api.commerce.data.mappers.BusinessHoursMapper;
 import com.rescuebites.api.commerce.data.models.Commerce;
 import com.rescuebites.api.product.controllers.requests.CreateProductRequest;
 import com.rescuebites.api.product.controllers.requests.UpdateProductRequest;
@@ -46,7 +47,7 @@ public class ProductMapper {
                 product.getCommerce().getImages().stream()
                         .map(ImageMapper::toImageResponse)
                         .collect(Collectors.toList()),
-                product.getCommerce().getOpeningHours(),
+                BusinessHoursMapper.toBusinessHoursResponseList(product.getCommerce().getBusinessHours()),
                 product.getName(),
                 product.getDescription(),
                 product.getStock(),
@@ -70,7 +71,7 @@ public class ProductMapper {
                 product.getProductId(),
                 product.getCommerce().getCommerceId(),
                 product.getCommerce().getName(),
-                product.getCommerce().getOpeningHours(),
+                BusinessHoursMapper.toBusinessHoursResponseList(product.getCommerce().getBusinessHours()),
                 product.getName(),
                 product.getDescription(),
                 product.getStock(),

--- a/src/main/java/com/rescuebites/api/product/facades/implementations/ProductValidationFacade.java
+++ b/src/main/java/com/rescuebites/api/product/facades/implementations/ProductValidationFacade.java
@@ -27,12 +27,6 @@ public class ProductValidationFacade implements IProductValidationFacade {
     private final IProductRepository productRepository;
 
     @Override
-    public Commerce findCommerceById(UUID commerceId) {
-        return commerceRepository.findByCommerceIdAndDeletedFalse(commerceId)
-                .orElseThrow(() -> new ResourceNotFoundException("Commerce", "id", commerceId));
-    }
-
-    @Override
     public Product findProductByIdAndCommerceIdOrThrowException(
             UUID productId,
             UUID commerceId

--- a/src/main/java/com/rescuebites/api/product/facades/interfaces/IProductValidationFacade.java
+++ b/src/main/java/com/rescuebites/api/product/facades/interfaces/IProductValidationFacade.java
@@ -14,12 +14,6 @@ import java.util.UUID;
 public interface IProductValidationFacade {
 
     /**
-     * Busca y retorna un comercio activo por su ID
-     * @throws ResourceNotFoundException si el comercio no existe o está inactivo
-     */
-    Commerce findCommerceById(UUID commerceId);
-
-    /**
      * Busca y retorna un producto por su ID y el ID del comercio
      * @throws ResourceNotFoundException si no hay un producto y un comercio
      */

--- a/src/main/java/com/rescuebites/api/product/services/implementations/ProductManagementServiceImpl.java
+++ b/src/main/java/com/rescuebites/api/product/services/implementations/ProductManagementServiceImpl.java
@@ -1,6 +1,7 @@
 package com.rescuebites.api.product.services.implementations;
 
 import com.rescuebites.api.commerce.data.models.Commerce;
+import com.rescuebites.api.commerce.facades.interfaces.ICommerceFacade;
 import com.rescuebites.api.product.controllers.requests.CreateProductRequest;
 import com.rescuebites.api.product.controllers.requests.UpdateProductRequest;
 import com.rescuebites.api.product.controllers.responses.ProductResponse;
@@ -31,6 +32,7 @@ public class ProductManagementServiceImpl implements IProductManagementService {
     private final IProductRepository productRepository;
     private final IImageFacade imageFacade;
     private final IProductValidationFacade productValidationFacade;
+    private final ICommerceFacade commerceFacade;
 
     @Override
     @Transactional
@@ -40,7 +42,7 @@ public class ProductManagementServiceImpl implements IProductManagementService {
             allEntries = true
     )
     public void createProduct(UUID commerceId, CreateProductRequest request, MultipartFile[] images) {
-        Commerce commerce = productValidationFacade.findCommerceById(commerceId);
+        Commerce commerce = commerceFacade.findCommerceByIdOrThrowException(commerceId);
 
         SecurityUtils.validateOwnership(commerce.getUser().getEmail());
         productValidationFacade.validateExpirationDate(request.getExpirationDate());
@@ -66,7 +68,7 @@ public class ProductManagementServiceImpl implements IProductManagementService {
     @Override
     @Transactional
     public Page<ProductResponse> getProductsByCommerce(UUID commerceId, Pageable pageable) {
-        Commerce commerce = productValidationFacade.findCommerceById(commerceId);
+        Commerce commerce = commerceFacade.findCommerceByIdOrThrowException(commerceId);
         SecurityUtils.validateOwnership(commerce.getUser().getEmail());
 
         Page<Product> products = productRepository.findByCommerceId(

--- a/src/main/java/com/rescuebites/api/security/utils/SecurityConstants.java
+++ b/src/main/java/com/rescuebites/api/security/utils/SecurityConstants.java
@@ -14,10 +14,17 @@ public class SecurityConstants {
             "/api/users/resend-verification-account",
             "/api/users/reset-password/**",
 
+            // Endpoints públicos (home, comercios, productos)
+            "/api/v1/public/**",
+
             // Búsqueda pública
             "/api/v1/search",
+            "/api/v1/search/**",
 
-            // Webhook de Mercado Pago (debe estar público para recibir notificaciones)
+            // Webhook y URLs de retorno de Mercado Pago
             "/api/v1/payments/webhook",
+            "/api/v1/payments/success",
+            "/api/v1/payments/failure",
+            "/api/v1/payments/pending",
     };
 }

--- a/src/main/java/com/rescuebites/api/shared/controllers/responses/SearchProductResponse.java
+++ b/src/main/java/com/rescuebites/api/shared/controllers/responses/SearchProductResponse.java
@@ -2,6 +2,7 @@ package com.rescuebites.api.shared.controllers.responses;
 
 import com.rescuebites.api.client.controllers.responses.ImageResponse;
 import com.rescuebites.api.client.data.enums.PreferenceType;
+import com.rescuebites.api.commerce.controllers.responses.BusinessHoursResponse;
 import com.rescuebites.api.product.data.enums.ProductCategory;
 import com.rescuebites.api.product.data.enums.ProductCondition;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -23,8 +24,8 @@ public record SearchProductResponse(
         @Schema(description = "Nombre del comercio")
         String commerceName,
 
-        @Schema(description = "Horario de apertura del comercio")
-        String commerceOpeningHours,
+        @Schema(description = "Horarios de atención del comercio")
+        List<BusinessHoursResponse> commerceBusinessHours,
 
         @Schema(description = "Nombre del producto")
         String name,


### PR DESCRIPTION
En esta PR implementé la gestión completa de los horarios de atención de los comercios, incluyendo validaciones tanto al agregar productos al carrito como al crear pedidos. Además, agregué la lógica para pedidos programados.

**Modelo de horarios:**

- Creé la entidad BusinessHours, que permite configurar turno único o turno partido (mañana/tarde) para cada día de la semana.
- Implementé CommerceScheduleStatus (record) para representar el estado actual del comercio:
  - Abierto
  - Cerrado por hoy
  - Cerrado pero reabre más tarde
- Creé BusinessHoursUtils, que contiene la lógica para determinar el estado del comercio según el día y la hora actual.

**Validaciones del carrito**

Al agregar un producto al carrito:
- Si el comercio está **cerrado por hoy**, no se permite agregar el producto.
- Si está **cerrado pero reabre más tarde**, sí se permite agregarlo.

**Validaciones del pedido**

- Si el comercio está **abierto** → el pedido se crea normalmente.
- Si está **cerrado por hoy** → se rechaza con error 400.
- Si **reabre más tarde** → se responde con error 409, incluyendo nextOpenTime y nextCloseTime en el body, para que el front pueda ofrecer la opción de programar el pedido.

También agregué el campo opcional scheduledPickupTime en CreateOrderRequest y el model Order.

Otro cambio que realicé fue actualizar ProductResponse y SearchProductResponse para incluir los horarios de atención del comercio.
