### PR TITLE
Agregar nuevos claims al JWT

### DIFF
--- a/src/main/java/com/rescuebites/api/client/repositories/IClientRepository.java
+++ b/src/main/java/com/rescuebites/api/client/repositories/IClientRepository.java
@@ -3,6 +3,9 @@ package com.rescuebites.api.client.repositories;
 import com.rescuebites.api.client.data.models.Client;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.Optional;
 import java.util.UUID;
 
@@ -10,4 +13,7 @@ public interface IClientRepository extends JpaRepository<Client, UUID> {
 
     @EntityGraph(attributePaths = {"preferences", "user"})
     Optional<Client> findByClientIdAndDeletedFalse(UUID clientId);
+
+    @Query("SELECT c FROM clients c WHERE c.user.userId = :userId AND c.deleted = false")
+    Optional<Client> findByUserId(@Param("userId") UUID userId);
 }

--- a/src/main/java/com/rescuebites/api/commerce/repositories/ICommerceRepository.java
+++ b/src/main/java/com/rescuebites/api/commerce/repositories/ICommerceRepository.java
@@ -123,4 +123,8 @@ public interface ICommerceRepository extends JpaRepository<Commerce, UUID> {
             @Param("normalizedLocality") String normalizedLocality,
             Pageable pageable
     );
+
+    // Nuevo método para buscar comercio por userId (no borrado)
+    @Query("SELECT c FROM commerces c WHERE c.user.userId = :userId AND c.deleted = false")
+    Optional<Commerce> findByUserId(@Param("userId") UUID userId);
 }

--- a/src/main/java/com/rescuebites/api/config/SecurityConfig.java
+++ b/src/main/java/com/rescuebites/api/config/SecurityConfig.java
@@ -72,7 +72,10 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PATCH, "/api/v1/commerces/*").hasRole("COMMERCE")
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/commerces/*").hasRole("COMMERCE")
 
-                        .requestMatchers(HttpMethod.POST,"/api/v1/commerces/*/products").hasRole("COMMERCE")
+                        // Productos de comercio
+                        .requestMatchers(HttpMethod.POST, "/api/v1/commerces/*/products").hasRole("COMMERCE")
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/commerces/*/products/*").hasRole("COMMERCE")
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/commerces/*/products/*").hasRole("COMMERCE")
 
                         // Operaciones del HOME del cliente (Públicas)
                         .requestMatchers(HttpMethod.GET, "/api/v1/public/commerces").permitAll()

--- a/src/main/java/com/rescuebites/api/product/data/enums/ProductCategory.java
+++ b/src/main/java/com/rescuebites/api/product/data/enums/ProductCategory.java
@@ -37,8 +37,8 @@ public enum ProductCategory {
     PERSONAL_HYGIENE(EnumSet.of(CommerceTypeEnum.KIOSK, CommerceTypeEnum.SUPERMARKET), "Higiene Personal"),
     CANDY(EnumSet.of(CommerceTypeEnum.KIOSK, CommerceTypeEnum.SUPERMARKET), "Golosinas"),
     SNACKS(EnumSet.of(CommerceTypeEnum.KIOSK, CommerceTypeEnum.SUPERMARKET), "Snacks"),
-    CIGARETTES(EnumSet.of(CommerceTypeEnum.KIOSK), "Cigarrillos"),
-    MAGAZINES(EnumSet.of(CommerceTypeEnum.KIOSK), "Revistas"),
+    CIGARETTES(EnumSet.of(CommerceTypeEnum.KIOSK, CommerceTypeEnum.SUPERMARKET), "Cigarrillos"),
+    MAGAZINES(EnumSet.of(CommerceTypeEnum.KIOSK, CommerceTypeEnum.SUPERMARKET), "Revistas"),
 
     // CATEGORÍAS CROSS (productos de otras categorías vendidos en super/kiosco)
     GREENGROCERY_SECTION(EnumSet.of(CommerceTypeEnum.SUPERMARKET), "Verdulería"),

--- a/src/main/java/com/rescuebites/api/security/dto/JwtAuthenticationDetails.java
+++ b/src/main/java/com/rescuebites/api/security/dto/JwtAuthenticationDetails.java
@@ -1,0 +1,12 @@
+package com.rescuebites.api.security.dto;
+
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+
+import java.util.UUID;
+
+public record JwtAuthenticationDetails(
+        WebAuthenticationDetails webDetails,
+        UUID commerceId,
+        String commerceType,
+        UUID clientId
+) {}

--- a/src/main/java/com/rescuebites/api/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/rescuebites/api/security/filter/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.rescuebites.api.security.filter;
 
+import com.rescuebites.api.security.dto.JwtAuthenticationDetails;
 import com.rescuebites.api.security.services.JwtService;
 import io.jsonwebtoken.ClaimJwtException;
 import jakarta.servlet.FilterChain;
@@ -8,6 +9,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
+import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -21,6 +23,7 @@ import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.UUID;
 
 import static com.rescuebites.api.security.utils.SecurityConstants.WHITELIST;
 
@@ -35,10 +38,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(
-            HttpServletRequest request,
-            HttpServletResponse response,
-            FilterChain filterChain
-    ) throws ServletException, IOException {
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) {
         try{
             /*
              Extraigo el token del Header Authorization de la request.
@@ -69,7 +72,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                             userDetails.getAuthorities()
                     );
 
-                    authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    // Extraer claims opcionales y guardarlos en details
+                    UUID commerceId = jwtService.extractCommerceIdFromToken(jwtToken);
+                    String commerceType = jwtService.extractCommerceTypeFromToken(jwtToken);
+                    UUID clientId = jwtService.extractClientIdFromToken(jwtToken);
+
+                    authentication.setDetails(new JwtAuthenticationDetails(
+                            new WebAuthenticationDetailsSource().buildDetails(request),
+                            commerceId,
+                            commerceType,
+                            clientId
+                    ));
 
                     SecurityContextHolder.getContext().setAuthentication(authentication);
                 } else {
@@ -94,17 +107,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) {
+    protected boolean shouldNotFilter(@NonNull HttpServletRequest request) {
         String path = request.getServletPath();
-
-        // Excluir OPTIONS requests
-        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
-            return true;
-        }
-
-        // Comparar con el whitelist de forma consistente
-        return Arrays.stream(WHITELIST)
-                .anyMatch(pattern -> pathMatcher.match(pattern, path) || path.startsWith(pattern));    }
+        return Arrays.stream(WHITELIST).anyMatch(p -> pathMatcher.match(p, path));
+    }
 
 }
-

--- a/src/main/java/com/rescuebites/api/security/services/JwtService.java
+++ b/src/main/java/com/rescuebites/api/security/services/JwtService.java
@@ -1,20 +1,28 @@
 package com.rescuebites.api.security.services;
 
+import com.rescuebites.api.client.repositories.IClientRepository;
+import com.rescuebites.api.commerce.data.models.Commerce;
+import com.rescuebites.api.commerce.repositories.ICommerceRepository;
 import com.rescuebites.api.users.data.models.User;
+import com.rescuebites.api.security.enums.Role;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import java.security.Key;
 import java.util.Date;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.function.Function;
 
 @Service
+@RequiredArgsConstructor
 public class JwtService {
 
     @Value("${jwt.secret}")
@@ -23,16 +31,39 @@ public class JwtService {
     @Value("${jwt.access-token-expiration}")
     private long jwtExpiration;
 
+    private final ICommerceRepository commerceRepository;
+    private final IClientRepository clientRepository;
+
     public String generateToken(final User user){
         return buildToken(user, jwtExpiration);
     }
 
     private String buildToken(User user, final long jwtExpiration) {
-        return Jwts.builder()
-                .claim("role", user.getRole())
+        var builder = Jwts.builder()
                 .setSubject(user.getEmail()) //Manera de identificar al usuario con el token
+                .claim("role", user.getRole()) // Agregamos el rol como un claim
                 .setIssuedAt(new Date(System.currentTimeMillis())) //Fecha de creacion del token
-                .setExpiration(new Date(System.currentTimeMillis() + jwtExpiration))
+                .setExpiration(new Date(System.currentTimeMillis() + jwtExpiration)); // Fecha de expiracion del token
+
+        // Si el usuario es un comercio, intentamos agregar commerceId y commerceType como claims
+        if (user.getRole() == Role.COMMERCE) {
+            Optional<Commerce> commerceOpt = commerceRepository.findByUserId(user.getUserId());
+            if (commerceOpt.isPresent()) {
+                Commerce commerce = commerceOpt.get();
+                if (commerce.getCommerceId() != null) {
+                    builder.claim("commerceId", commerce.getCommerceId().toString());
+                }
+                if (commerce.getCommerceTypes() != null && !commerce.getCommerceTypes().isEmpty()) {
+                    // Tomamos el primer tipo como tipo principal
+                    builder.claim("commerceType", commerce.getCommerceTypes().get(0).getName().name());
+                }
+            }
+        } else if (user.getRole() == Role.CLIENT) {
+            clientRepository.findByUserId(user.getUserId())
+                    .ifPresent(client -> builder.claim("clientId", client.getClientId()));
+        }
+
+        return builder
                 .signWith(getSignInKey(), SignatureAlgorithm.HS256)
                 .compact(); //Genera el token en formato String
     }
@@ -73,6 +104,20 @@ public class JwtService {
 
     public Date extractExpiration(String token) {
         return extractClaim(token, Claims::getExpiration);
+    }
+
+    public UUID extractCommerceIdFromToken(String token) {
+        String val = extractClaim(token, claims -> claims.get("commerceId", String.class));
+        return val == null ? null : UUID.fromString(val);
+    }
+
+    public String extractCommerceTypeFromToken(String token) {
+        return extractClaim(token, claims -> claims.get("commerceType", String.class));
+    }
+
+    public UUID extractClientIdFromToken(String token) {
+        String val = extractClaim(token, claims -> claims.get("clientId", String.class));
+        return val == null ? null : UUID.fromString(val);
     }
 
     public boolean isTokenValid(String token, UserDetails userDetails){

--- a/src/main/java/com/rescuebites/api/security/utils/SecurityUtils.java
+++ b/src/main/java/com/rescuebites/api/security/utils/SecurityUtils.java
@@ -1,9 +1,12 @@
 package com.rescuebites.api.security.utils;
 
 import com.rescuebites.api.exceptions.custom_exceptions.UnauthorizedException;
+import com.rescuebites.api.security.dto.JwtAuthenticationDetails;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+
+import java.util.UUID;
 
 @Component
 public class SecurityUtils {
@@ -46,5 +49,44 @@ public class SecurityUtils {
                 .findFirst()
                 .map(authority -> authority.getAuthority().replace("ROLE_", ""))
                 .orElseThrow(() -> new UnauthorizedException("No se pudo determinar el rol del usuario"));
+    }
+
+    public static UUID getAuthenticatedCommerceId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new UnauthorizedException("No estás autenticado");
+        }
+
+        Object details = authentication.getDetails();
+        if (details instanceof JwtAuthenticationDetails jwtDetails) {
+            return jwtDetails.commerceId();
+        }
+        return null;
+    }
+
+    public static String getAuthenticatedCommerceType() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new UnauthorizedException("No estás autenticado");
+        }
+
+        Object details = authentication.getDetails();
+        if (details instanceof JwtAuthenticationDetails jwtDetails) {
+            return jwtDetails.commerceType();
+        }
+        return null;
+    }
+
+    public static UUID getAuthenticatedClientId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new UnauthorizedException("No estás autenticado");
+        }
+
+        Object details = authentication.getDetails();
+        if (details instanceof JwtAuthenticationDetails jwtDetails) {
+            return jwtDetails.clientId();
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Implementé una mejora en el token JWT para incluir información adicional del usuario autenticado. Ahora el token contiene los identificadores del comercio (commerceId) y del cliente (clientId), junto con sus roles y el commerceType (en caso de que role="COMMERCE").
Con esto, el backend puede resolver la identidad del usuario directamente desde el token, evitando tener que hacer consultas adicionales a la base de datos.
